### PR TITLE
implementation: product card images

### DIFF
--- a/src/components/related/ProductCard.jsx
+++ b/src/components/related/ProductCard.jsx
@@ -107,21 +107,20 @@ class ProductCard extends React.Component {
 
   render() {
     const { productCardId, updateAppProductId } = this.props;
-    const { name, category, price, salePrice, rating, primaryImg } = this.state;
+    const { name, category, price, salePrice, rating } = this.state;
+    let primaryImg = this.state.primaryImg;
 
-    const imgStyle = {
-      backgroundImage: `url(${primaryImg})`
-    }
+    if (!primaryImg) { primaryImg = 'https://nayemdevs.com/wp-content/uploads/2020/03/default-product-image.png'; }
 
     return (
       <div className='product-card'
-        onClick={() => { updateAppProductId(productCardId); }}
-        style={imgStyle}>
+        onClick={() => { updateAppProductId(productCardId); }}>
+        <img className='card-img' src={primaryImg}></img>
         <div className='card-info'>
           <p className='card-category'>{category}</p>
+          <h4 className='card-name'>{name}</h4>
           <p className='card-price'>{'$'}{price}</p>
           <p className='card-sale'>{salePrice}</p>
-          <h4 className='card-name'>{name}</h4>
         </div>
         <StarRating className='card-rating' rating={rating}/>
       </div>

--- a/src/components/related/ProductCard.jsx
+++ b/src/components/related/ProductCard.jsx
@@ -13,6 +13,7 @@ class ProductCard extends React.Component {
       price: '...',
       salePrice: '...',
       rating: null,
+      primaryImg: '...',
       initialRequestMade: false
     }
   }
@@ -61,7 +62,9 @@ class ProductCard extends React.Component {
       axios(pricePicsRequestConfig)
         .then((response) => {
           const data = response.data.results[0];
-          this.setState({price: data.original_price, salePrice: data.sale_price});
+          this.setState({price: data.original_price,
+            salePrice: data.sale_price,
+            primaryImg: data.photos[0].url});
         })
         .catch((error) => {
           console.log('HTTP request to fetch product prices failed');
@@ -104,15 +107,22 @@ class ProductCard extends React.Component {
 
   render() {
     const { productCardId, updateAppProductId } = this.props;
-    const { name, category, price, salePrice, rating } = this.state;
+    const { name, category, price, salePrice, rating, primaryImg } = this.state;
+
+    const imgStyle = {
+      backgroundImage: `url(${primaryImg})`
+    }
 
     return (
       <div className='product-card'
-        onClick={() => { updateAppProductId(productCardId); }}>
-        <h4 className='card-name'>{name}</h4>
-        <p className='card-category'>{category}</p>
-        <p className='card-price'>{'$'}{price}</p>
-        <p className='card-sale'>{salePrice}</p>
+        onClick={() => { updateAppProductId(productCardId); }}
+        style={imgStyle}>
+        <div className='card-info'>
+          <p className='card-category'>{category}</p>
+          <p className='card-price'>{'$'}{price}</p>
+          <p className='card-sale'>{salePrice}</p>
+          <h4 className='card-name'>{name}</h4>
+        </div>
         <StarRating className='card-rating' rating={rating}/>
       </div>
     );

--- a/src/components/related/ProductCard.jsx
+++ b/src/components/related/ProductCard.jsx
@@ -62,9 +62,11 @@ class ProductCard extends React.Component {
       axios(pricePicsRequestConfig)
         .then((response) => {
           const data = response.data.results[0];
-          this.setState({price: data.original_price,
+          this.setState({
+            price: data.original_price,
             salePrice: data.sale_price,
-            primaryImg: data.photos[0].url});
+            primaryImg: data.photos[0].url
+          });
         })
         .catch((error) => {
           console.log('HTTP request to fetch product prices failed');
@@ -110,7 +112,9 @@ class ProductCard extends React.Component {
     const { name, category, price, salePrice, rating } = this.state;
     let primaryImg = this.state.primaryImg;
 
-    if (!primaryImg) { primaryImg = 'https://nayemdevs.com/wp-content/uploads/2020/03/default-product-image.png'; }
+    if (!primaryImg) {
+      primaryImg = 'https://nayemdevs.com/wp-content/uploads/2020/03/default-product-image.png';
+    }
 
     return (
       <div className='product-card'

--- a/src/components/related/ProductCard.jsx
+++ b/src/components/related/ProductCard.jsx
@@ -13,7 +13,7 @@ class ProductCard extends React.Component {
       price: '...',
       salePrice: '...',
       rating: null,
-      primaryImg: '...',
+      primaryImg: null,
       initialRequestMade: false
     }
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -45,21 +45,25 @@ h1 {
 }
 
 .product-card-list {
-  display: 'flex';
-  flex-flow: row wrap;
-  height: 100%;
+  display: flex;
+  flex-flow: row;
+  overflow-x: scroll;
 }
 
 .product-card {
   background-color: $container-bg;
-  height: 8rem;
+  background-position: center;
+  background-size: 100% 100%;
+
+  display: flex;
+  flex-direction: column;
+  height: 20rem;
   width: 16rem;
   padding: 5px;
   margin: 5px;
 
   border: 1px solid black;
   border-radius: 10px;
-  background-color: $container-bg;
 }
 .product-card:hover {
   cursor: pointer;
@@ -70,8 +74,36 @@ h4 {
   margin: 5px;
 }
 
-.product-card p {
-  margin-left: 5px;
+.card-info {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  background: rgba(255, 255, 255, 0.507);
+  padding: 3px;
+  border-radius: 10px 10px 0px 0px;
+}
+
+.card-category {
+  margin: 0px;
+  text-transform: uppercase;
+  font-size: 2vh;
+}
+
+.card-name {
+  margin: 0px;
+  font-size: 3vh;
+}
+
+.card-price {
+  margin: 0px;
+}
+
+.card-sale {
+  margin: 0px;
+}
+
+.card-rating {
+  align-self: flex-end;
 }
 /* Related ---------------------(end) */
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -112,19 +112,21 @@ h1 {
 .product-card-list {
   display: flex;
   flex-flow: row;
-  overflow-x: scroll;
+  width: 90vw;
+  overflow-y: scroll;
 }
 
 .product-card {
+  display: flex;
+  flex-direction: column;
+
   background-color: $container-bg;
+  background: linear-gradient(rgb(245, 245, 245), rgb(224, 224, 224));
   background-position: center;
   background-size: 100% 100%;
 
-  display: flex;
-  flex-direction: column;
   height: 20rem;
-  width: 16rem;
-  padding: 5px;
+  min-width: 11rem;
   margin: 5px;
 
   border: 1px solid black;
@@ -132,7 +134,8 @@ h1 {
 }
 .product-card:hover {
   cursor: pointer;
-  color: $link-btn-color;
+  background-color:rgb(243, 243, 243);
+  filter: drop-shadow(0 0 0.2rem rgba(0, 0, 0, 0.26));
 }
 
 h4 {
@@ -142,15 +145,14 @@ h4 {
 .card-img {
   width: 100%;
   height: 60%;
+  border-bottom: 1px solid black;
+  border-radius: 10px 10px 0px 0px;
 }
 
 .card-info {
   display: flex;
   flex-direction: column;
-  flex-wrap: wrap;
-  background: rgba(255, 255, 255, 0.507);
   padding: 3px;
-  border-radius: 10px 10px 0px 0px;
 }
 
 .card-category {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -139,6 +139,11 @@ h4 {
   margin: 5px;
 }
 
+.card-img {
+  width: 100%;
+  height: 60%;
+}
+
 .card-info {
   display: flex;
   flex-direction: column;

--- a/tests/related.test.js
+++ b/tests/related.test.js
@@ -21,13 +21,17 @@ describe("Product Card", () => {
     expect(productCard.props().onClick).toBeDefined();
   });
 
-  it('renders a product image using the state primaryImg url', () => {
+  it('renders a product image using the state primaryImg url or the default image if the primaryUrl is null', () => {
     const productCard = shallow(<ProductCard />);
     const cardImg = productCard.find('.card-img');
     const productCardState = productCard.state();
 
+    if (!productCardState.primaryImg) {
+      productCardState.primaryImg ="https://nayemdevs.com/wp-content/uploads/2020/03/default-product-image.png"
+    }
+
     expect(cardImg).toHaveLength(1);
-    console.log(cardImg.prop('src')).toEqual(productCardState.primaryImg);
+    expect(cardImg.prop('src')).toEqual(productCardState.primaryImg);
   });
 
   it('should call updateAppProductId on click', () => {

--- a/tests/related.test.js
+++ b/tests/related.test.js
@@ -21,6 +21,15 @@ describe("Product Card", () => {
     expect(productCard.props().onClick).toBeDefined();
   });
 
+  it('renders a product image using the state primaryImg url', () => {
+    const productCard = shallow(<ProductCard />);
+    const cardImg = productCard.find('.card-img');
+    const productCardState = productCard.state();
+
+    expect(cardImg).toHaveLength(1);
+    console.log(cardImg.prop('src')).toEqual(productCardState.primaryImg);
+  });
+
   it('should call updateAppProductId on click', () => {
     const updateAppProductId = jest.fn();
     const productCard = shallow(<ProductCard updateAppProductId={updateAppProductId} />);


### PR DESCRIPTION
The product card should display preview images of the related products. The images which appear on the product card should be the same that appear in the Overview module on the item detail page for that product.

By default, the preview image displayed on each card will be the primary image for that product. This should be the same which first appears on the image detail page’s image gallery.

ticket: https://trello.com/c/KgUfNF3j/29-related-product-card-preview-images